### PR TITLE
Magisk Compatibility fix for 27005+

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -76,7 +76,7 @@ unzip -o "$ZIPFILE" module.prop -d $TMPDIR >&2
 [ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
 
 $BOOTMODE && MODDIRNAME=modules_update || MODDIRNAME=modules
-MODULEROOT=$NVBASE/$MODDIRNAME
+MODULEROOT=/data/adb/$MODDIRNAME
 MODID=`grep_prop id $TMPDIR/module.prop`
 MODPATH=$MODULEROOT/$MODID
 MODNAME=`grep_prop name $TMPDIR/module.prop`
@@ -144,8 +144,8 @@ done
 
 if $BOOTMODE; then
   # Update info for Magisk Manager
-  mktouch $NVBASE/modules/$MODID/update
-  cp -af $MODPATH/module.prop $NVBASE/modules/$MODID/module.prop
+  mktouch /data/adb/modules/$MODID/update
+  cp -af $MODPATH/module.prop /data/adb/modules/$MODID/module.prop
 fi
 
 # Copy over custom sepolicy rules


### PR DESCRIPTION
This fixes the errors caused by the removal of NVBASE in Magisk starting from version 27005 and up. Tested and working on both a OnePlus 10 Pro and OnePlus 6T using said Magisk versions.