### PR TITLE
Patch1

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -90,21 +90,26 @@ replace_emojis() {
 # Function to clear app cache
 clear_cache() {
     local app_name="$1"
-    if [ -d "/data/data/$app_name" ]; then
-        find /data -type d -path "*$app_name*/*cache*" -exec rm -rf {} +
-        am force-stop "$app_name"
-        ui_print "- Cleared cache for $app_name"
-    else
-        ui_print "- $app_name cache not found, skipping"
+    local app_display_name=$(display_name "$app_name")
+	
+    # Check if app exists
+    if ! package_installed "$app_name"; then
+        ui_print "- Skipping: $app_display_name (not installed)"
+        return 0
     fi
-}
+	
+	ui_print "- Cleaning cache: $app_display_name"
+	
+    for subpath in /cache /code_cache /app_webview /files/GCache; do
+        target_dir="/data/data/${app_name}${subpath}"
+        if [ -d "$target_dir" ]; then
+            rm -rf "$target_dir"
+        fi
+    done
 
-  
-# Extract module files
-ui_print "- Extracting module files"
-unzip -o "$ZIPFILE" 'system/*' -d "$MODPATH" >&2 || {
-    ui_print "- Failed to extract module files"
-    exit 1
+    # Force-stop
+    am force-stop "$app_name"
+    ui_print "- Cache cleared: $app_display_name"
 }
 
 

--- a/customize.sh
+++ b/customize.sh
@@ -75,8 +75,8 @@ replace_emojis() {
     local app_name="$1"
     local app_dir="$2"
     local emoji_dir="$3"
-  local target_filename="$4"
-  local app_display_name=$(display_name "$app_name")
+    local target_filename="$4"
+    local app_display_name=$(display_name "$app_name")
     
     if package_installed "$app_name"; then
         ui_print "- Detected: $app_display_name"

--- a/customize.sh
+++ b/customize.sh
@@ -13,16 +13,13 @@ POSTFSDATA=false
 LATESTARTSERVICE=true
 
 ui_print "*******************************"
-ui_print "*       iOS Emoji 17.4.6      *"
+ui_print "*       iOS Emoji 17.4.7      *"
 ui_print "*******************************"
 
 # Definitions
 FONT_DIR="$MODPATH/system/fonts"
 FONT_EMOJI="NotoColorEmoji.ttf"
 SYSTEM_FONT_FILE="/system/fonts/NotoColorEmoji.ttf"
-MSG_DIR="/data/data/com.facebook.orca"
-FB_DIR="/data/data/com.facebook.katana"
-FB_EMOJI_DIR="app_ras_blobs" 
 
 
 # Function to check if a package is installed
@@ -33,6 +30,19 @@ package_installed() {
     else
         return 1
     fi
+}
+
+# Function to get user-friendly app name from package name
+display_name() {
+    local package_name="$1"
+    case "$package_name" in
+        "com.facebook.orca") echo "Messenger" ;;
+        "com.facebook.katana") echo "Facebook" ;;
+        "com.facebook.lite") echo "Facebook Lite" ;;
+        "com.facebook.mlite") echo "Messenger Lite" ;;
+        "com.google.android.inputmethod.latin") echo "Gboard" ;;
+        *) echo "$package_name" ;;  # Default to package name if not found
+    esac
 }
 
 # Function to mount a font file
@@ -55,9 +65,7 @@ mount_font() {
     
     if mount -o bind "$source" "$target"; then
         chmod 644 "$target"
-        ui_print "- Successfully mounted $source to $target and set permissions"
     else
-        ui_print "- Failed to mount $source to $target"
         return 1
     fi
 }
@@ -67,14 +75,15 @@ replace_emojis() {
     local app_name="$1"
     local app_dir="$2"
     local emoji_dir="$3"
+	local target_filename="$4"
+	local app_display_name=$(display_name "$app_name")
     
     if package_installed "$app_name"; then
-        ui_print "- $app_name Installed Detected"
-        ui_print "- Mounting custom emoji font for $app_name"
-        mount_font "$FONT_DIR/$FONT_EMOJI" "$app_dir/$emoji_dir/FacebookEmoji.ttf"
-        am force-stop "$app_name" && ui_print "- Done"
+        ui_print "- Detected: $app_display_name"
+        mount_font "$FONT_DIR/$FONT_EMOJI" "$app_dir/$emoji_dir/$target_filename"
+        ui_print "- Emojis mounted: $app_display_name"
     else
-        ui_print "- $app_name not installed, skipping"
+        ui_print "- Not installed: $app_display_name"
     fi
 }
 

--- a/customize.sh
+++ b/customize.sh
@@ -13,7 +13,7 @@ POSTFSDATA=false
 LATESTARTSERVICE=true
 
 ui_print "*******************************"
-ui_print "*       iOS Emoji 17.4.7      *"
+ui_print "*          iOS Emoji 17.4.7         *"
 ui_print "*******************************"
 
 # Definitions

--- a/customize.sh
+++ b/customize.sh
@@ -75,8 +75,8 @@ replace_emojis() {
     local app_name="$1"
     local app_dir="$2"
     local emoji_dir="$3"
-	   local target_filename="$4"
-	   local app_display_name=$(display_name "$app_name")
+local target_filename="$4"
+local app_display_name=$(display_name "$app_name")
     
     if package_installed "$app_name"; then
         ui_print "- Detected: $app_display_name"

--- a/customize.sh
+++ b/customize.sh
@@ -75,8 +75,8 @@ replace_emojis() {
     local app_name="$1"
     local app_dir="$2"
     local emoji_dir="$3"
-local target_filename="$4"
-local app_display_name=$(display_name "$app_name")
+  local target_filename="$4"
+  local app_display_name=$(display_name "$app_name")
     
     if package_installed "$app_name"; then
         ui_print "- Detected: $app_display_name"

--- a/customize.sh
+++ b/customize.sh
@@ -75,8 +75,8 @@ replace_emojis() {
     local app_name="$1"
     local app_dir="$2"
     local emoji_dir="$3"
-	local target_filename="$4"
-	local app_display_name=$(display_name "$app_name")
+	   local target_filename="$4"
+	   local app_display_name=$(display_name "$app_name")
     
     if package_installed "$app_name"; then
         ui_print "- Detected: $app_display_name"

--- a/customize.sh
+++ b/customize.sh
@@ -112,6 +112,11 @@ clear_cache() {
     ui_print "- Cache cleared: $app_display_name"
 }
 
+# Extract module files
+unzip -o "$ZIPFILE" 'system/*' -d "$MODPATH" >&2 || {
+    ui_print "- Failed to extract module files"
+    exit 1
+}
 
 # Replace system emoji fonts
 ui_print "- Installing Emojis"
@@ -139,14 +144,20 @@ else
 fi
 
 # Replace Facebook and Messenger emojis
-replace_emojis "com.facebook.orca" "$MSG_DIR" "$FB_EMOJI_DIR"
-replace_emojis "com.facebook.katana" "$FB_DIR" "$FB_EMOJI_DIR"
+replace_emojis "com.facebook.orca" "/data/data/com.facebook.orca" "app_ras_blobs" "FacebookEmoji.ttf"
+clear_cache "com.facebook.orca"
+replace_emojis "com.facebook.katana" "/data/data/com.facebook.katana" "app_ras_blobs" "FacebookEmoji.ttf"
+clear_cache "com.facebook.katana"
+
+# Replace Lite app emojis
+replace_emojis "com.facebook.lite" "/data/data/com.facebook.lite" "files" "emoji_font.ttf"
+clear_cache "com.facebook.lite"
+replace_emojis "com.facebook.mlite" "/data/data/com.facebook.mlite" "files" "emoji_font.ttf"
+clear_cache "com.facebook.mlite"
   
 # Clear Gboard cache if installed
-if package_installed "com.google.android.inputmethod.latin"; then
-    ui_print "- Clearing Gboard Cache"
-    clear_cache "com.google.android.inputmethod.latin"
-fi
+ui_print "- Clearing Gboard Cache"
+clear_cache "com.google.android.inputmethod.latin"
   
 # Remove /data/fonts directory for Android 12+ instead of replacing the files (removing the need to run the troubleshooting step, thanks @reddxae)
 if [ -d "/data/fonts" ]; then

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=iOS_Emoji
 name=iOS 17.4 Emoji font
-version=v17.4.6
-versionCode=17406
+version=v17.4.7
+versionCode=17407
 author=Keinta15
 description=Systemlessly replaces emoji font with iOS 17.4 Emoji
 updateJson=https://raw.githubusercontent.com/Keinta15/Magisk-iOS-Emoji/main/updater.json

--- a/service.sh
+++ b/service.sh
@@ -10,7 +10,7 @@ MAX_LOG_FILES=3 # Keep up to 3 archived logs
 MAX_LOG_AGE_DAYS=7 # Delete logs older than 7 days
 
 # Facebook app package names
-FACEBOOK_APPS="com.facebook.orca com.facebook.katana"
+FACEBOOK_APPS="com.facebook.orca com.facebook.katana com.facebook.lite com.facebook.mlite"
 
 # GMS font services
 GMS_FONT_PROVIDER="com.google.android.gms/com.google.android.gms.fonts.provider.FontsProvider"
@@ -51,7 +51,7 @@ service_exists() {
 
 # Log script header
 log "================================================"
-log "iOS Emoji 17.4.6 service.sh Script"
+log "iOS Emoji 17.4.7 service.sh Script"
 log "Brand: $(getprop ro.product.brand)"
 log "Device: $(getprop ro.product.model)"
 log "Android Version: $(getprop ro.build.version.release)"
@@ -80,7 +80,7 @@ replace_emoji_fonts() {
     fi
 
     # Find all .ttf files containing "Emoji" in their names
-    EMOJI_FONTS=$(find /data/data -name "*Emoji*.ttf" -print)
+    EMOJI_FONTS=$(find /data/data -iname "*emoji*.ttf" -print)
 
     if [ -z "$EMOJI_FONTS" ]; then
         log "INFO: No emoji fonts found to replace. Skipping."


### PR DESCRIPTION
### Added
- **Facebook Lite/Messenger Lite Support**  
  Added emoji replacement compatibility for:
  - Facebook Lite (`com.facebook.lite`)
  - Messenger Lite (`com.facebook.mlite`)
- **`display_name()` function**
  Added function to display app names instead of package name `com.facebook.katana`

### Changed
- **Case-Insensitive Font Detection**  
  Modified `replace_emoji_fonts()` in `service.sh` to use:  
  `find -iname "*emoji*.ttf"` instead of case-sensitive matching

### Fixed
- **Cache Clearing Lag**  
  Rewrote `clear_cache()` to eliminate delays caused by recursive `find` in `/data`  
  *New implementation uses direct path targeting for faster cleanup*