### PR TITLE
Update emoji font to iOS 26.4 with Unicode 17.0 support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 
 ## Changelog
+v26.4
+- Added 26.4 Emojis ([Unicode 17.0](https://emojipedia.org/unicode-17.0)) Thanks to [mistu01/MEEMEmoji](https://github.com/mistu01/MEEMEmoji) for the source.
+
 v18.4.1
 - Fixed Messenger occasionally reverting to default emojis
 - Fixed a bug in service.sh that failed to properly disable the GMS font provider for all Google apps, preventing some apps from using the iOS emoji font

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Systemlessly replaces the emoji font with iOS Emoji.
 *Example of iOS emojis displayed on an Android device.*
 
 ## Changelog
+### v26.4
+- Added 26.4 Emojis ([Unicode 17.0](https://emojipedia.org/unicode-17.0)) Thanks to [mistu01/MEEMEmoji](https://github.com/mistu01/MEEMEmoji) for the source.
+
 ### v18.4.1
 - Fixed Messenger occasionally reverting to default emojis
 - Fixed a bug in service.sh that failed to properly disable the GMS font provider for all Google apps, preventing some apps from using the iOS emoji font

--- a/customize.sh
+++ b/customize.sh
@@ -12,9 +12,9 @@ PROPFILE=false
 POSTFSDATA=false
 LATESTARTSERVICE=true
 
-ui_print "*******************************"
-ui_print "*          iOS Emoji 18.4           *"
-ui_print "*******************************"
+ui_print "*************************************"
+ui_print "*          iOS Emoji 26.4           *"
+ui_print "*************************************"
 
 # Definitions
 FONT_DIR="$MODPATH/system/fonts"

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=iOS_Emoji
-name=iOS 18.4 Emoji font
-version=v18.4
-versionCode=18400
+name=iOS 26.4 Emoji font
+version=v26.4
+versionCode=26400
 author=Keinta15
-description=Systemlessly replaces emoji font with iOS 18.4 Emoji
+description=Systemlessly replaces emoji font with iOS 26.4 Emoji
 updateJson=https://raw.githubusercontent.com/Keinta15/Magisk-iOS-Emoji/main/updater.json

--- a/updater.json
+++ b/updater.json
@@ -1,6 +1,6 @@
 {
-  "version": "v18.4.1",
-  "versionCode": 18401,
-  "zipUrl": "https://github.com/Keinta15/Magisk-iOS-Emoji/releases/download/v18.4.1/Magisk_iOS_Emoji_18.4.1.zip",
+  "version": "v26.4",
+  "versionCode": 26400,
+  "zipUrl": "https://github.com/Keinta15/Magisk-iOS-Emoji/releases/download/v26.4/Magisk_iOS_Emoji_26.4.zip",
   "changelog": "https://raw.githubusercontent.com/Keinta15/Magisk-iOS-Emoji/main/Changelog.md"
  }


### PR DESCRIPTION
Requesting the pull again, just wanted to clean things up a bit so I ended up forking the project again to keep it separate from the previous repo.
Either way, once again thanks for your work! <3 